### PR TITLE
feat: add unit test project for Credfeto.Enumeration.Source.Generation.Generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 - Unit test project for Credfeto.Enumeration.Source.Generation.Attributes to achieve 100% code coverage
+- Unit test project for Credfeto.Enumeration.Source.Generation.Generics with 100% line, branch, and method coverage
 ### Fixed
 ### Changed
 - Dependencies - Updated Meziantou.Analyzer to 3.0.98

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/Credfeto.Enumeration.Source.Generation.Generics.Tests.csproj
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/Credfeto.Enumeration.Source.Generation.Generics.Tests.csproj
@@ -1,0 +1,85 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <Company>Mark Ridgwell</Company>
+    <Copyright>Mark Ridgwell</Copyright>
+    <DebuggerSupport>true</DebuggerSupport>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <Features>strict;flow-analysis</Features>
+    <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>latest</LangVersion>
+    <NeutralLanguage>en-GB</NeutralLanguage>
+    <NoWarn />
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <Nullable>enable</Nullable>
+    <OptimizationPreference>speed</OptimizationPreference>
+    <OutputType>Exe</OutputType>
+    <PackageLicense>https://raw.githubusercontent.com/credfeto/credfeto-enum-source-generation/main/LICENSE</PackageLicense>
+    <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
+    <Product>Source Generation</Product>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TieredCompilation>true</TieredCompilation>
+    <TieredPGO>true</TieredPGO>
+    <TreatSpecificWarningsAsErrors />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
+    <!-- error NU1902: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
+  </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />
+  <ItemGroup>
+    <ProjectReference Include="..\Credfeto.Enumeration.Source.Generation.Generics\Credfeto.Enumeration.Source.Generation.Generics.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.25.2243" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.CodeAnalysis" Version="7.2.0.1978" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.25.2243" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.98" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SmartAnalyzers.CSharpExtensions.Annotations" Version="4.2.11" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="All" ExcludeAssets="runtime" />
+  </ItemGroup>
+</Project>

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionReflectionTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionReflectionTests.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class EnumGetDescriptionReflectionTests
+{
+    [Fact]
+    public void GetDescriptionReflectionReturnsNameWhenNoDescriptionAttribute()
+    {
+        Assert.Equal(
+            expected: nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION),
+            actual: TestEnumWithDescription.WITHOUT_DESCRIPTION.GetDescriptionReflection()
+        );
+    }
+
+    [Fact]
+    public void GetDescriptionReflectionReturnsDescriptionWhenAttributePresent()
+    {
+        Assert.Equal(
+            expected: "First described value",
+            actual: TestEnumWithDescription.WITH_DESCRIPTION.GetDescriptionReflection()
+        );
+    }
+
+    [Fact]
+    public void GetDescriptionReflectionReturnsEmptyStringForUndefinedValue()
+    {
+        const TestEnumWithDescription unknown = (TestEnumWithDescription)999;
+
+        Assert.Equal(expected: string.Empty, actual: unknown.GetDescriptionReflection());
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
@@ -17,7 +17,7 @@ public sealed class EnumGetDescriptionTests
         string secondResult = TestEnumWithDescription.WITHOUT_DESCRIPTION.GetDescription();
 
         Assert.Equal(expected: nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION), actual: firstResult);
-        Assert.Equal(expected: firstResult, actual: secondResult);
+        Assert.Equal(expected: nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION), actual: secondResult);
     }
 
     [Fact]
@@ -27,6 +27,6 @@ public sealed class EnumGetDescriptionTests
         string secondResult = TestEnumWithDescription.WITH_DESCRIPTION.GetDescription();
 
         Assert.Equal(expected: "First described value", actual: firstResult);
-        Assert.Equal(expected: firstResult, actual: secondResult);
+        Assert.Equal(expected: "First described value", actual: secondResult);
     }
 }

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetDescriptionTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class EnumGetDescriptionTests
+{
+    [Fact]
+    public void GetDescriptionReturnsCachedNameWhenNoDescriptionAttribute()
+    {
+        string firstResult = TestEnumWithDescription.WITHOUT_DESCRIPTION.GetDescription();
+        string secondResult = TestEnumWithDescription.WITHOUT_DESCRIPTION.GetDescription();
+
+        Assert.Equal(expected: nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION), actual: firstResult);
+        Assert.Equal(expected: firstResult, actual: secondResult);
+    }
+
+    [Fact]
+    public void GetDescriptionReturnsCachedDescriptionWhenAttributePresent()
+    {
+        string firstResult = TestEnumWithDescription.WITH_DESCRIPTION.GetDescription();
+        string secondResult = TestEnumWithDescription.WITH_DESCRIPTION.GetDescription();
+
+        Assert.Equal(expected: "First described value", actual: firstResult);
+        Assert.Equal(expected: firstResult, actual: secondResult);
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetNameReflectionTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetNameReflectionTests.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class EnumGetNameReflectionTests
+{
+    [Theory]
+    [InlineData(TestEnumWithDescription.WITHOUT_DESCRIPTION, nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION))]
+    [InlineData(TestEnumWithDescription.WITH_DESCRIPTION, nameof(TestEnumWithDescription.WITH_DESCRIPTION))]
+    public void GetNameReflectionReturnsNameForDefinedValue(TestEnumWithDescription value, string expected)
+    {
+        Assert.Equal(expected: expected, actual: value.GetNameReflection());
+    }
+
+    [Fact]
+    public void GetNameReflectionReturnsEmptyStringForUndefinedValue()
+    {
+        const TestEnumWithDescription unknown = (TestEnumWithDescription)999;
+
+        Assert.Equal(expected: string.Empty, actual: unknown.GetNameReflection());
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetNameTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/EnumGetNameTests.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class EnumGetNameTests
+{
+    [Theory]
+    [InlineData(TestEnumWithDescription.WITHOUT_DESCRIPTION, nameof(TestEnumWithDescription.WITHOUT_DESCRIPTION))]
+    [InlineData(TestEnumWithDescription.WITH_DESCRIPTION, nameof(TestEnumWithDescription.WITH_DESCRIPTION))]
+    public void GetNameReturnsCachedName(TestEnumWithDescription value, string expected)
+    {
+        string firstResult = value.GetName();
+        string secondResult = value.GetName();
+
+        Assert.Equal(expected: expected, actual: firstResult);
+        Assert.Equal(expected: expected, actual: secondResult);
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/IsDefinedReflectionTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/IsDefinedReflectionTests.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class IsDefinedReflectionTests
+{
+    [Theory]
+    [InlineData(TestEnumWithDescription.WITHOUT_DESCRIPTION)]
+    [InlineData(TestEnumWithDescription.WITH_DESCRIPTION)]
+    public void IsDefinedReflectionReturnsTrueForDefinedValue(TestEnumWithDescription value)
+    {
+        Assert.True(value.IsDefinedReflection(), $"{value} should be a defined enum member");
+    }
+
+    [Fact]
+    public void IsDefinedReflectionReturnsFalseForUndefinedValue()
+    {
+        const TestEnumWithDescription unknown = (TestEnumWithDescription)999;
+
+        Assert.False(unknown.IsDefinedReflection(), "Cast value 999 is not a defined enum member");
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/IsDefinedTests.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/IsDefinedTests.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0013: Test classes should be derived from TestBase",
+    Justification = "Not in this case"
+)]
+public sealed class IsDefinedTests
+{
+    [Theory]
+    [InlineData(TestEnumWithDescription.WITHOUT_DESCRIPTION)]
+    [InlineData(TestEnumWithDescription.WITH_DESCRIPTION)]
+    public void IsDefinedReturnsTrueForDefinedValue(TestEnumWithDescription value)
+    {
+        bool firstResult = value.IsDefined();
+        bool secondResult = value.IsDefined();
+
+        Assert.True(firstResult, $"{value} should be a defined enum member");
+        Assert.True(secondResult, $"{value} should still be a defined enum member on second lookup");
+    }
+
+    [Fact]
+    public void IsDefinedReturnsFalseForUndefinedValue()
+    {
+        const TestEnumWithDescription unknown = (TestEnumWithDescription)999;
+
+        bool firstResult = unknown.IsDefined();
+        bool secondResult = unknown.IsDefined();
+
+        Assert.False(firstResult, "Cast value 999 is not a defined enum member");
+        Assert.False(secondResult, "Cast value 999 is still not a defined enum member on second lookup");
+    }
+}

--- a/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/TestEnumWithDescription.cs
+++ b/src/Credfeto.Enumeration.Source.Generation.Generics.Tests/TestEnumWithDescription.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+
+namespace Credfeto.Enumeration.Source.Generation.Generics.Tests;
+
+public enum TestEnumWithDescription
+{
+    WITHOUT_DESCRIPTION = 0,
+
+    [Description("First described value")]
+    WITH_DESCRIPTION = 1,
+}

--- a/src/Credfeto.Enumeration.Source.Generation.slnx
+++ b/src/Credfeto.Enumeration.Source.Generation.slnx
@@ -15,6 +15,7 @@
   <Project Path="Credfeto.Enumeration.Source.Generation.Attributes.Tests/Credfeto.Enumeration.Source.Generation.Attributes.Tests.csproj" />
   <Project Path="Credfeto.Enumeration.Source.Generation.Benchmark.Tests\Credfeto.Enumeration.Source.Generation.Benchmark.Tests.csproj" />
   <Project Path="Credfeto.Enumeration.Source.Generation.Generics/Credfeto.Enumeration.Source.Generation.Generics.csproj" />
+  <Project Path="Credfeto.Enumeration.Source.Generation.Generics.Tests/Credfeto.Enumeration.Source.Generation.Generics.Tests.csproj" />
   <Project Path="Credfeto.Enumeration.Source.Generation.Models.Tests/Credfeto.Enumeration.Source.Generation.Models.Tests.csproj" />
   <Project Path="Credfeto.Enumeration.Source.Generation.Models/Credfeto.Enumeration.Source.Generation.Models.csproj" />
   <Project Path="Credfeto.Enumeration.Source.Generation/Credfeto.Enumeration.Source.Generation.csproj" />


### PR DESCRIPTION
## Summary

- Creates `Credfeto.Enumeration.Source.Generation.Generics.Tests` unit test project
- Achieves 100% line, branch, and method coverage for `EnumHelpers`
- Covers all six public methods: `GetNameReflection`, `GetName`, `GetDescriptionReflection`, `GetDescription`, `IsDefinedReflection`, `IsDefined`
- Both cache-miss and cache-hit paths covered for `GetName`, `GetDescription`, and `IsDefined`
- `GetDescriptionReflection` tested with a value with a `[Description]` attribute, without one, and with an undefined enum value (null field info path)
- Adds `TestEnumWithDescription` enum in the test project for parameterised tests

Closes #99